### PR TITLE
compat: add toReversed to arrays for Firefox compatibility

### DIFF
--- a/hex_world_generator/hex_world_generator.js
+++ b/hex_world_generator/hex_world_generator.js
@@ -49,6 +49,13 @@ function set_seed(s)
     g_seed = s;
 }
 
+// Hackjob of a shim for Firefox compatibility.
+if (Array.prototype.toReversed === undefined) {
+    Array.prototype.toReversed = function() {
+        return this.slice().reverse();
+    }
+}
+
 function init()
 {    	
     canvas = document.getElementById("canvas")


### PR DESCRIPTION
Firefox has either not added Array.prototype.toReversed yet or it is yet to be added.
I do not understand Mozilla's bureaucracy so until then this shim should get the map generator working.
On the plus side, once toReversed IS added, this block will move out of the way for the native version to do its job; preferably this block would be removed.

Thanks to /u/bocxorocx on Reddit for pointing out the problem.

See also: https://bugzilla.mozilla.org/show_bug.cgi?id=1729563